### PR TITLE
feat: launch Người Ở Lại Media prototype

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# NGUOI-O-LAI
+# Người Ở Lại Media – Hồi Ức Của Ước Mơ
+
+Prototype Next.js app cho dự án tự truyện đa phương tiện "Người Ở Lại – Hồi Ức Của Ước Mơ".
+
+## Tính năng nổi bật
+
+- Hai tab công khai Podcast / Video với Stay Mode, Linear Journey Mode, lưu tiến độ localStorage.
+- Trang Timeline tóm tắt 5 Phần, hai giọng nội tâm và cột mốc 2020–2025.
+- Stay Mode: theme tối dịu, thông điệp chữa lành.
+- Admin Panel (mock) gồm đăng nhập, CRUD, bảng quản trị, Link Resolver đa nhà cung cấp, AI Gemini giả lập cho cover/mô tả/tag.
+- Bộ adapter xử lý Google Drive, Dropbox, OneDrive, YouTube, Vimeo, SoundCloud, liên kết trực tiếp và S3/R2.
+
+## Cấu trúc
+
+```
+src/
+  app/
+    page.tsx         # Trang công khai chính
+    timeline/        # Bản đồ hành trình
+    admin/           # Dashboard + AI tools
+  components/        # Header, tabs, Stay Mode context...
+  data/episodes.ts   # Mock DB theo Phần/Chương
+  lib/               # mock Gemini & Link Resolver
+```
+
+## Chạy dự án
+
+> Repo không kèm `node_modules`. Bạn cần cài đặt thủ công.
+
+```bash
+npm install
+npm run dev
+```
+
+Ứng dụng chạy tại `http://localhost:3000`.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,7 @@
+const nextConfig = {
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "nguoi-o-lai-media",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "clsx": "2.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.0",
+    "@types/react": "18.2.43",
+    "@types/react-dom": "18.2.17",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.56.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "8.4.32",
+    "tailwindcss": "3.3.6",
+    "typescript": "5.3.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import Link from "next/link";
+import { podcastEpisodes, videoItems } from "@/data/episodes";
+import { generateCovers, generateDescription, generateTags, GeminiCover } from "@/lib/mock-gemini";
+import { resolveMediaLink, ResolverOutput, listAdapters } from "@/lib/link-resolver";
+
+const emptyForm = {
+  id: "",
+  title: "",
+  description: "",
+  part_index: "I",
+  chapter_index: 1,
+  tags: "",
+  source_provider: "",
+  source_type: "stream",
+  source_url_input: "",
+  resolved_stream_url: "",
+  cover_url: "",
+  status: "draft"
+};
+
+type FormState = typeof emptyForm;
+
+type Collection = "podcast" | "video";
+
+export default function AdminPage() {
+  const [isAuthed, setIsAuthed] = useState(false);
+  const [authError, setAuthError] = useState("\u00a0");
+  const [podcasts, setPodcasts] = useState(podcastEpisodes);
+  const [videos, setVideos] = useState(videoItems);
+  const [form, setForm] = useState<FormState>(emptyForm);
+  const [collection, setCollection] = useState<Collection>("podcast");
+  const [resolverPreview, setResolverPreview] = useState<ResolverOutput | null>(null);
+  const [covers, setCovers] = useState<GeminiCover[]>([]);
+  const [aiBusy, setAiBusy] = useState(false);
+
+  const data = collection === "podcast" ? podcasts : videos;
+
+  const handleLogin = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const email = formData.get("email");
+    const password = formData.get("password");
+    if (email === "admin@nguoiolai.vn" && password === "nguoiolai") {
+      setIsAuthed(true);
+      setAuthError("\u00a0");
+    } else {
+      setAuthError("Sai thông tin đăng nhập");
+    }
+  };
+
+  const handleChange = (field: keyof FormState, value: string | number) => {
+    const next = { ...form, [field]: value };
+    setForm(next);
+    if (field === "source_url_input" && value) {
+      const resolved = resolveMediaLink(String(value));
+      setResolverPreview(resolved);
+      setForm((prev) => ({ ...prev, resolved_stream_url: resolved.resolved_stream_url, source_provider: resolved.source_provider }));
+    }
+  };
+
+  const resetForm = () => {
+    setForm(emptyForm);
+    setResolverPreview(null);
+    setCovers([]);
+  };
+
+  const upsertItem = (event: FormEvent) => {
+    event.preventDefault();
+    const payload = {
+      ...form,
+      id: form.id || crypto.randomUUID(),
+      tags: form.tags ? form.tags.split(",").map((tag) => tag.trim()) : []
+    };
+
+    if (collection === "podcast") {
+      setPodcasts((prev) => {
+        const exists = prev.some((item) => item.id === payload.id);
+        if (exists) {
+          return prev.map((item) => (item.id === payload.id ? (payload as any) : item));
+        }
+        return [...prev, payload as any];
+      });
+    } else {
+      setVideos((prev) => {
+        const exists = prev.some((item) => item.id === payload.id);
+        if (exists) {
+          return prev.map((item) => (item.id === payload.id ? (payload as any) : item));
+        }
+        return [...prev, payload as any];
+      });
+    }
+    resetForm();
+  };
+
+  const handleEdit = (id: string) => {
+    const found = data.find((item) => item.id === id);
+    if (!found) return;
+    setForm({
+      ...emptyForm,
+      ...found,
+      tags: (found as any).tags?.join?.(", ") ?? ""
+    });
+    setResolverPreview(
+      resolveMediaLink((found as any).resolvedStreamUrl ?? (found as any).resolved_stream_url ?? "")
+    );
+  };
+
+  const handleDelete = (id: string) => {
+    if (collection === "podcast") {
+      setPodcasts((prev) => prev.filter((item) => item.id !== id));
+    } else {
+      setVideos((prev) => prev.filter((item) => item.id !== id));
+    }
+  };
+
+  const handleAiDescription = async () => {
+    setAiBusy(true);
+    const description = await generateDescription(form.title || "Người Ở Lại");
+    setForm((prev) => ({ ...prev, description }));
+    setAiBusy(false);
+  };
+
+  const handleAiTags = async () => {
+    setAiBusy(true);
+    const tags = await generateTags(form.title);
+    setForm((prev) => ({ ...prev, tags: tags.join(", ") }));
+    setAiBusy(false);
+  };
+
+  const handleAiCover = async () => {
+    setAiBusy(true);
+    const nextCovers = await generateCovers(form.title || "NguoiOLai");
+    setCovers(nextCovers);
+    setAiBusy(false);
+  };
+
+  const adaptersList = useMemo(() => listAdapters().join(", "), []);
+
+  if (!isAuthed) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-dusk">
+        <form onSubmit={handleLogin} className="w-full max-w-md rounded-3xl border border-white/10 bg-black/40 p-8 text-white">
+          <h1 className="text-2xl font-semibold">Admin Panel</h1>
+          <p className="text-sm text-white/70">Đăng nhập để quản lý podcast và video.</p>
+          <label className="mt-6 block text-sm">Email
+            <input name="email" type="email" className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3" required />
+          </label>
+          <label className="mt-4 block text-sm">Mật khẩu
+            <input name="password" type="password" className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3" required />
+          </label>
+          <p className="mt-3 text-sm text-red-400">{authError}</p>
+          <button type="submit" className="mt-6 w-full rounded-2xl bg-candle px-4 py-3 text-black font-semibold">Đăng nhập</button>
+          <Link href="/" className="mt-4 block text-center text-sm text-white/70">← Về trang công khai</Link>
+        </form>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-dusk px-4 py-10 text-white">
+      <div className="mx-auto max-w-6xl">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-semibold">Dashboard</h1>
+            <p className="text-sm text-white/70">Quản lý tập Podcast &amp; Video với công cụ AI Gemini giả lập.</p>
+          </div>
+          <Link href="/" className="rounded-full border border-white/20 px-4 py-2 text-sm text-white/80">← Trang công khai</Link>
+        </div>
+        <div className="mt-8 rounded-3xl border border-white/10 bg-black/30 p-6">
+          <div className="flex flex-wrap items-center gap-4">
+            <p className="text-sm uppercase tracking-[0.4em] text-candle/70">Bộ sưu tập</p>
+            <div className="flex gap-2">
+              {(["podcast", "video"] as Collection[]).map((col) => (
+                <button
+                  key={col}
+                  onClick={() => setCollection(col)}
+                  className={col === collection ? "rounded-full bg-candle px-4 py-2 text-black" : "rounded-full border border-white/20 px-4 py-2 text-white/70"}
+                >
+                  {col === "podcast" ? "Podcast Manager" : "Video Manager"}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="mt-6 overflow-x-auto">
+            <table className="min-w-full text-left text-sm">
+              <thead className="text-xs uppercase text-white/50">
+                <tr>
+                  <th className="px-2 py-2">Title</th>
+                  <th className="px-2 py-2">Description</th>
+                  <th className="px-2 py-2">Part</th>
+                  <th className="px-2 py-2">Chapter</th>
+                  <th className="px-2 py-2">Source Provider</th>
+                  <th className="px-2 py-2">Source Type</th>
+                  <th className="px-2 py-2">Source URL</th>
+                  <th className="px-2 py-2">Resolved URL</th>
+                  <th className="px-2 py-2">Tags</th>
+                  <th className="px-2 py-2">Cover</th>
+                  <th className="px-2 py-2">Status</th>
+                  <th className="px-2 py-2">Edit</th>
+                  <th className="px-2 py-2">Delete</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.map((item) => (
+                  <tr key={item.id} className="border-t border-white/5">
+                    <td className="px-2 py-3 font-semibold">{item.title}</td>
+                    <td className="px-2 py-3 text-white/70">{(item as any).description}</td>
+                    <td className="px-2 py-3">{(item as any).part || (item as any).part_index}</td>
+                    <td className="px-2 py-3">{(item as any).chapterIndex || (item as any).chapter_index || "-"}</td>
+                    <td className="px-2 py-3">{(item as any).sourceProvider || (item as any).source_provider}</td>
+                    <td className="px-2 py-3">{(item as any).source_type ?? "stream"}</td>
+                    <td className="px-2 py-3 text-candle/80">
+                      <span className="line-clamp-1">{(item as any).sourceUrlInput || (item as any).source_url_input || "—"}</span>
+                    </td>
+                    <td className="px-2 py-3 text-candle/80">
+                      <span className="line-clamp-1">{(item as any).resolvedStreamUrl || (item as any).resolved_stream_url}</span>
+                    </td>
+                    <td className="px-2 py-3 text-xs">{((item as any).tags ?? []).join?.(", ")}</td>
+                    <td className="px-2 py-3 text-xs">{(item as any).coverUrl || (item as any).cover_url}</td>
+                    <td className="px-2 py-3 text-xs capitalize">{(item as any).status ?? "public"}</td>
+                    <td className="px-2 py-3">
+                      <button className="text-candle" onClick={() => handleEdit(item.id)}>Sửa</button>
+                    </td>
+                    <td className="px-2 py-3">
+                      <button className="text-red-300" onClick={() => handleDelete(item.id)}>Xóa</button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <section className="mt-8 grid gap-6 lg:grid-cols-2">
+          <form onSubmit={upsertItem} className="rounded-3xl border border-white/10 bg-black/30 p-6">
+            <h2 className="text-2xl font-semibold">Thêm / Chỉnh sửa</h2>
+            <label className="mt-4 block text-sm">Title
+              <input value={form.title} onChange={(event) => handleChange("title", event.target.value)} className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3" required />
+            </label>
+            <label className="mt-4 block text-sm">Description
+              <textarea value={form.description} onChange={(event) => handleChange("description", event.target.value)} className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3" rows={3} />
+            </label>
+            <div className="mt-4 grid gap-4 sm:grid-cols-3">
+              <label className="block text-sm">Phần
+                <select value={form.part_index} onChange={(event) => handleChange("part_index", event.target.value)} className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3">
+                  {["I", "II", "III", "IV", "V"].map((p) => (
+                    <option key={p}>{p}</option>
+                  ))}
+                </select>
+              </label>
+              <label className="block text-sm">Chương
+                <input type="number" value={form.chapter_index} onChange={(event) => handleChange("chapter_index", Number(event.target.value))} className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3" />
+              </label>
+              <label className="block text-sm">Status
+                <select value={form.status} onChange={(event) => handleChange("status", event.target.value)} className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3">
+                  <option value="draft">Draft</option>
+                  <option value="published">Published</option>
+                </select>
+              </label>
+            </div>
+            <label className="mt-4 block text-sm">Tags (cách nhau bởi dấu phẩy)
+              <input value={form.tags} onChange={(event) => handleChange("tags", event.target.value)} className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3" />
+            </label>
+            <label className="mt-4 block text-sm">Nguồn (URL)
+              <input value={form.source_url_input} onChange={(event) => handleChange("source_url_input", event.target.value)} className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3" placeholder="Dán link Google Drive, Dropbox, Vimeo..." />
+            </label>
+            <label className="mt-4 block text-sm">Resolved stream URL
+              <input value={form.resolved_stream_url} onChange={(event) => handleChange("resolved_stream_url", event.target.value)} className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3" />
+            </label>
+            <label className="mt-4 block text-sm">Cover URL
+              <input value={form.cover_url} onChange={(event) => handleChange("cover_url", event.target.value)} className="mt-1 w-full rounded-2xl border border-white/10 bg-black/40 p-3" />
+            </label>
+            {resolverPreview && (
+              <div className="mt-4 rounded-2xl border border-candle/30 bg-candle/5 p-4 text-sm text-white/80">
+                <p className="text-xs uppercase tracking-[0.4em] text-candle/80">Link Resolver Preview</p>
+                <p>Provider: {resolverPreview.source_provider}</p>
+                <p>Embed: {resolverPreview.embed_type}</p>
+                <p>MIME: {resolverPreview.mime_type}</p>
+                <p>Duration: {resolverPreview.duration_estimate}</p>
+                <p className="text-xs text-white/60">Note: {resolverPreview.note ?? "—"}</p>
+              </div>
+            )}
+            <button type="submit" className="mt-6 w-full rounded-2xl bg-candle px-4 py-3 text-black font-semibold">Lưu nội dung</button>
+          </form>
+          <div className="rounded-3xl border border-white/10 bg-black/30 p-6">
+            <h2 className="text-2xl font-semibold">AI Tools (Gemini)</h2>
+            <div className="mt-4 space-y-4 text-sm">
+              <button onClick={handleAiDescription} className="w-full rounded-2xl border border-white/10 px-4 py-3 text-left hover:border-candle" disabled={aiBusy}>
+                ✨ Tạo mô tả 2–3 câu
+              </button>
+              <button onClick={handleAiTags} className="w-full rounded-2xl border border-white/10 px-4 py-3 text-left hover:border-candle" disabled={aiBusy}>
+                🏷️ Gợi ý thẻ ưu tiên sang chấn / phân ly / gia đình
+              </button>
+              <button onClick={handleAiCover} className="w-full rounded-2xl border border-white/10 px-4 py-3 text-left hover:border-candle" disabled={aiBusy}>
+                🖼️ Sinh 3 cover theo motif (cửa khép, nồi cơm, Mi Đô, giấc mơ tro, ngọn nến)
+              </button>
+            </div>
+            {covers.length > 0 && (
+              <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                {covers.map((cover) => (
+                  <button
+                    key={cover.id}
+                    onClick={() => setForm((prev) => ({ ...prev, cover_url: cover.url }))}
+                    className="rounded-2xl border border-white/10 bg-black/40 p-3 text-left text-xs text-white/70"
+                  >
+                    <img src={cover.url} alt={cover.title} className="h-32 w-full rounded-xl object-cover" />
+                    {cover.title}
+                  </button>
+                ))}
+              </div>
+            )}
+            <div className="mt-6 rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-white/70">
+              <p className="text-xs uppercase tracking-[0.4em] text-candle/80">Adapters khả dụng</p>
+              <p>{adaptersList}</p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,46 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --bg: #0b0b0d;
+  --text: #f6f1e9;
+  --muted: #b8b6af;
+  --card: #1e1c20;
+  --accent: #f6c28b;
+}
+
+body {
+  color: var(--text);
+  background: radial-gradient(circle at top, rgba(246,194,139,0.2), transparent 50%),
+    var(--bg);
+  min-height: 100vh;
+  font-family: 'Inter', 'Be Vietnam Pro', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body.stay-mode {
+  background: #0d0d0d;
+  color: #bfbfbf;
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+}
+
+.fade-card {
+  animation: slowFade 1s ease both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { Be_Vietnam_Pro } from "next/font/google";
+import { StayModeProvider } from "@/components/stay-mode-context";
+
+const beVietnam = Be_Vietnam_Pro({ subsets: ["latin"], weight: ["400", "500", "600", "700"] });
+
+export const metadata: Metadata = {
+  title: "Người Ở Lại Media",
+  description: "Hồi ức của ước mơ – hành trình chữa lành bằng âm thanh, hình ảnh và AI."
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="vi">
+      <body className={beVietnam.className}>
+        <StayModeProvider>{children}</StayModeProvider>
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,33 @@
+import { SiteHeader } from "@/components/site-header";
+import { MainExperience } from "@/components/main-experience";
+import { partsMeta } from "@/data/episodes";
+
+export default function HomePage() {
+  return (
+    <main className="pb-16">
+      <SiteHeader />
+      <section className="mx-auto mt-10 max-w-6xl rounded-3xl border border-white/10 bg-white/5 px-6 py-10 text-white shadow-lullaby">
+        <p className="text-sm uppercase tracking-[0.5em] text-candle/80">Hành trình 2020 – 2025</p>
+        <h2 className="mt-3 text-4xl font-semibold leading-tight">Người Ở Lại – Hồi Ức Của Ước Mơ</h2>
+        <p className="mt-4 text-lg text-white/80">
+          Podcast và video song hành kể về hai giọng nội tâm – Người Ở Lại và Phần Yếu Mềm – giữa những phòng bệnh, căn bếp
+          trống và ánh đèn vàng.
+        </p>
+        <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {partsMeta.map((part) => (
+            <div key={part.part} className="rounded-2xl border border-white/10 bg-black/20 p-4">
+              <p className="text-xs uppercase tracking-[0.4em] text-candle/70">Phần {part.part}</p>
+              <h3 className="text-lg font-semibold">{part.title}</h3>
+              <p className="text-sm text-white/70">{part.summary}</p>
+              <p className="mt-2 text-xs text-soft-green">Biểu tượng: {part.symbols.join(", ")}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+      <MainExperience />
+      <footer className="mx-auto mt-10 max-w-4xl rounded-3xl border border-white/10 bg-black/40 px-6 py-6 text-center text-sm text-white/70">
+        Nếu nội dung chạm đến vùng ký ức nhạy cảm, hãy nghỉ một chút. Ở đây, bạn không phải vội.
+      </footer>
+    </main>
+  );
+}

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -1,0 +1,64 @@
+import Link from "next/link";
+import { partsMeta, timelineEvents } from "@/data/episodes";
+
+const voices = [
+  {
+    name: "Người Ở Lại",
+    description: "Giọng mạnh mẽ, trấn tĩnh, luôn giữ ánh đèn cháy trong phòng bệnh."
+  },
+  {
+    name: "Phần Yếu Mềm",
+    description: "Giọng thì thầm, đại diện cho sang chấn, giấc mơ màu tro và những cơn phân ly."
+  }
+];
+
+export default function TimelinePage() {
+  return (
+    <main className="min-h-screen bg-dusk pb-16 text-white">
+      <div className="mx-auto max-w-5xl px-4 py-10">
+        <Link href="/" className="text-sm text-candle">
+          ← Trở về trang chính
+        </Link>
+        <h1 className="mt-4 text-4xl font-semibold">Bản Đồ Hành Trình</h1>
+        <p className="mt-3 text-white/80">
+          Khám phá 5 Phần của dự án, hai giọng nội tâm và chuỗi sự kiện từ 2020 đến 2025.
+        </p>
+        <section className="mt-10 grid gap-6 md:grid-cols-2">
+          {partsMeta.map((part) => (
+            <div key={part.part} className="rounded-3xl border border-white/10 bg-white/5 p-5">
+              <p className="text-xs uppercase tracking-[0.4em] text-candle/70">Phần {part.part}</p>
+              <h2 className="text-2xl font-semibold">{part.title}</h2>
+              <p className="text-sm text-white/70">{part.summary}</p>
+              <p className="mt-2 text-xs text-soft-green">Biểu tượng: {part.symbols.join(", ")}</p>
+              <p className="text-xs text-soft-green">Giọng góp mặt: {part.voices.join(", ")}</p>
+            </div>
+          ))}
+        </section>
+        <section className="mt-12 rounded-3xl border border-white/10 bg-black/30 p-6">
+          <h2 className="text-2xl font-semibold">Hai giọng nội tâm</h2>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            {voices.map((voice) => (
+              <div key={voice.name} className="rounded-2xl border border-white/10 bg-black/40 p-4">
+                <h3 className="text-xl font-semibold text-candle">{voice.name}</h3>
+                <p className="text-sm text-white/70">{voice.description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+        <section className="mt-12">
+          <h2 className="text-2xl font-semibold">Timeline 2020 – 2025</h2>
+          <ol className="mt-6 space-y-5 border-l border-white/20 pl-6">
+            {timelineEvents.map((event) => (
+              <li key={event.year} className="relative">
+                <div className="absolute -left-3 top-1 h-4 w-4 rounded-full border border-candle bg-dusk" />
+                <p className="text-sm uppercase tracking-[0.3em] text-candle/70">{event.year}</p>
+                <h3 className="text-xl font-semibold">{event.title}</h3>
+                <p className="text-white/70">{event.detail}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/main-experience.tsx
+++ b/src/components/main-experience.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { PodcastTab } from "@/components/podcast-tab";
+import { VideoTab } from "@/components/video-tab";
+import { useStayMode } from "@/components/stay-mode-context";
+import clsx from "clsx";
+
+const tabs = [
+  { id: "podcast", label: "Podcast" },
+  { id: "video", label: "Video" }
+] as const;
+
+export type TabId = (typeof tabs)[number]["id"];
+
+export function MainExperience() {
+  const [tab, setTab] = useState<TabId>("podcast");
+  const { stayMode } = useStayMode();
+  const TabComponent = useMemo(() => (tab === "podcast" ? PodcastTab : VideoTab), [tab]);
+
+  return (
+    <section className={clsx("mx-auto mt-6 max-w-6xl rounded-3xl border px-4 py-6 shadow-lullaby", stayMode ? "border-white/5 bg-[#111]" : "border-white/10 bg-white/5")}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-4 border-b border-white/10 pb-4">
+        <div>
+          <p className="text-sm uppercase tracking-[0.3em] text-candle/70">Hành trình song song</p>
+          <h2 className="text-2xl font-semibold text-white">Podcast &amp; Video</h2>
+        </div>
+        <div className="flex rounded-full bg-black/30 p-1 text-sm text-white">
+          {tabs.map((t) => (
+            <button
+              key={t.id}
+              onClick={() => setTab(t.id)}
+              className={clsx(
+                "flex-1 rounded-full px-4 py-2 transition",
+                tab === t.id ? "bg-candle text-black" : "text-white/70"
+              )}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="mt-6">
+        <TabComponent />
+      </div>
+    </section>
+  );
+}

--- a/src/components/podcast-tab.tsx
+++ b/src/components/podcast-tab.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import clsx from "clsx";
+import { podcastEpisodes } from "@/data/episodes";
+import { useStayMode } from "@/components/stay-mode-context";
+
+interface ProgressMap {
+  [episodeId: string]: number;
+}
+
+const parts = ["I", "II", "III", "IV", "V"] as const;
+
+export function PodcastTab() {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [selectedId, setSelectedId] = useState<string>(podcastEpisodes[0]?.id ?? "");
+  const [progress, setProgress] = useState<ProgressMap>({});
+  const [linearQueue, setLinearQueue] = useState<string[] | null>(null);
+  const [currentLinearIndex, setCurrentLinearIndex] = useState(0);
+  const { stayMode } = useStayMode();
+
+  const grouped = useMemo(() => {
+    return parts.map((part) => ({
+      part,
+      episodes: podcastEpisodes.filter((ep) => ep.part === part)
+    }));
+  }, []);
+
+  useEffect(() => {
+    const storedProgress = localStorage.getItem("podcast-progress");
+    const storedSelected = localStorage.getItem("podcast-last");
+    if (storedProgress) {
+      setProgress(JSON.parse(storedProgress));
+    }
+    if (storedSelected) {
+      setSelectedId(storedSelected);
+    }
+  }, []);
+
+  const currentEpisode = podcastEpisodes.find((ep) => ep.id === selectedId) ?? podcastEpisodes[0];
+
+  const handleTimeUpdate = () => {
+    const player = audioRef.current;
+    if (!player || !currentEpisode) return;
+    const pct = player.currentTime / (player.duration || 1);
+    const newProgress = { ...progress, [currentEpisode.id]: pct };
+    setProgress(newProgress);
+    localStorage.setItem("podcast-progress", JSON.stringify(newProgress));
+  };
+
+  const handleSelect = (episodeId: string) => {
+    setSelectedId(episodeId);
+    localStorage.setItem("podcast-last", episodeId);
+  };
+
+  const startLinearJourney = () => {
+    const sorted = [...podcastEpisodes].sort((a, b) => a.chapterIndex - b.chapterIndex);
+    setLinearQueue(sorted.map((ep) => ep.id));
+    setCurrentLinearIndex(0);
+    handleSelect(sorted[0].id);
+  };
+
+  const handleEnded = () => {
+    if (!linearQueue) return;
+    const nextIndex = currentLinearIndex + 1;
+    if (nextIndex < linearQueue.length) {
+      setCurrentLinearIndex(nextIndex);
+      handleSelect(linearQueue[nextIndex]);
+    } else {
+      setLinearQueue(null);
+    }
+  };
+
+  const percent = currentEpisode ? Math.round((progress[currentEpisode.id] || 0) * 100) : 0;
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)]">
+      <div className="space-y-4">
+        <button
+          onClick={startLinearJourney}
+          className="w-full rounded-2xl border border-candle/40 bg-candle/10 px-4 py-3 text-left text-sm font-semibold text-candle transition hover:border-candle"
+        >
+          Nghe từ đầu (Linear Journey Mode)
+          <p className="text-xs font-normal text-white/70">Tự động phát toàn bộ câu chuyện theo thứ tự chương.</p>
+        </button>
+        <div className="space-y-4">
+          {grouped.map(({ part, episodes }) => (
+            <details key={part} open className="rounded-2xl border border-white/10 bg-black/20 p-4">
+              <summary className="cursor-pointer text-lg font-semibold text-white">Phần {part}</summary>
+              <div className="mt-3 space-y-3">
+                {episodes.map((episode) => (
+                  <button
+                    key={episode.id}
+                    onClick={() => handleSelect(episode.id)}
+                    className={clsx(
+                      "flex w-full items-center gap-4 rounded-2xl border px-3 py-3 text-left transition",
+                      selectedId === episode.id
+                        ? "border-candle bg-candle/10 text-white"
+                        : "border-white/10 text-white/80 hover:border-white/30"
+                    )}
+                  >
+                    <div className={clsx("h-16 w-16 flex-shrink-0 rounded-2xl bg-cover bg-center", stayMode ? "grayscale" : "")}
+                      style={{ backgroundImage: `url(${episode.coverUrl})` }}
+                    />
+                    <div>
+                      <p className="text-sm uppercase tracking-[0.2em] text-candle/70">Chương {episode.chapterIndex}</p>
+                      <h3 className="text-base font-semibold text-white">{episode.title}</h3>
+                      <p className="text-sm text-white/70">{episode.description}</p>
+                      <p className="text-xs text-white/50">{episode.duration} – Đã nghe {Math.round((progress[episode.id] || 0) * 100)}%</p>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+      <div className="rounded-3xl border border-white/10 bg-black/30 p-6">
+        <div className="flex items-center gap-4">
+          <div
+            className={clsx("h-28 w-28 flex-shrink-0 rounded-3xl bg-cover bg-center", stayMode ? "grayscale" : "")}
+            style={{ backgroundImage: `url(${currentEpisode?.coverUrl ?? ""})` }}
+          />
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-candle/70">Đang phát</p>
+            <h3 className="text-xl font-semibold text-white">{currentEpisode?.title}</h3>
+            <p className="text-sm text-white/70">{currentEpisode?.description}</p>
+            <p className="text-xs text-soft-green">Gợi ý chăm sóc: {currentEpisode?.moodPrompt}</p>
+          </div>
+        </div>
+        <div className="mt-6 space-y-3">
+          <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
+            <div className="h-full rounded-full bg-candle" style={{ width: `${percent}%` }} />
+          </div>
+          <p className="text-xs uppercase tracking-[0.3em] text-white/60">{percent}% đã nghe</p>
+          <audio
+            key={currentEpisode?.id}
+            ref={audioRef}
+            controls
+            className="w-full rounded-2xl bg-black/60 p-2"
+            src={currentEpisode?.resolvedStreamUrl}
+            onTimeUpdate={handleTimeUpdate}
+            onEnded={handleEnded}
+          />
+          {linearQueue && (
+            <p className="text-xs text-white/70">
+              Linear Journey Mode • Chương {currentLinearIndex + 1}/{linearQueue.length}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { StayModeToggle } from "@/components/stay-mode-toggle";
+
+export function SiteHeader() {
+  return (
+    <header className="sticky top-0 z-30 w-full bg-dusk/80 backdrop-blur">
+      <div className="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.2em] text-candle/80">Người Ở Lại Media</p>
+          <h1 className="text-2xl font-semibold text-white">Hồi Ức Của Ước Mơ</h1>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Link
+            href="/timeline"
+            className="rounded-full border border-white/30 px-4 py-2 text-center text-sm text-white transition hover:border-candle hover:text-candle"
+          >
+            Bản Đồ Hành Trình
+          </Link>
+          <StayModeToggle />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/stay-mode-context.tsx
+++ b/src/components/stay-mode-context.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+interface StayModeContextValue {
+  stayMode: boolean;
+  toggleStayMode: () => void;
+}
+
+const StayModeContext = createContext<StayModeContextValue | undefined>(undefined);
+
+export function StayModeProvider({ children }: { children: React.ReactNode }) {
+  const [stayMode, setStayMode] = useState(false);
+
+  useEffect(() => {
+    const stored = typeof window !== "undefined" ? localStorage.getItem("stay-mode") : null;
+    if (stored) {
+      setStayMode(stored === "true");
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    document.body.classList.toggle("stay-mode", stayMode);
+    localStorage.setItem("stay-mode", String(stayMode));
+  }, [stayMode]);
+
+  const value = useMemo(
+    () => ({
+      stayMode,
+      toggleStayMode: () => setStayMode((prev) => !prev)
+    }),
+    [stayMode]
+  );
+
+  return <StayModeContext.Provider value={value}>{children}</StayModeContext.Provider>;
+}
+
+export function useStayMode() {
+  const ctx = useContext(StayModeContext);
+  if (!ctx) throw new Error("useStayMode must be used within StayModeProvider");
+  return ctx;
+}

--- a/src/components/stay-mode-toggle.tsx
+++ b/src/components/stay-mode-toggle.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useStayMode } from "@/components/stay-mode-context";
+import clsx from "clsx";
+
+export function StayModeToggle() {
+  const { stayMode, toggleStayMode } = useStayMode();
+
+  return (
+    <button
+      onClick={toggleStayMode}
+      className={clsx(
+        "flex items-center gap-2 rounded-full px-4 py-2 text-sm transition focus-visible:outline focus-visible:outline-2",
+        stayMode
+          ? "bg-stay-accent/20 text-stay-text focus-visible:outline-stay-accent"
+          : "bg-white/10 text-white focus-visible:outline-candle"
+      )}
+    >
+      <span className="h-2 w-2 rounded-full bg-candle shadow-inner" aria-hidden />
+      {stayMode ? "Thoát Stay Mode" : "Bật Stay Mode"}
+    </button>
+  );
+}

--- a/src/components/video-tab.tsx
+++ b/src/components/video-tab.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
+import { videoItems } from "@/data/episodes";
+import { useStayMode } from "@/components/stay-mode-context";
+
+const iframeProviders = new Set(["YouTube", "Vimeo", "SoundCloud"]);
+
+export function VideoTab() {
+  const [selectedId, setSelectedId] = useState<string>(videoItems[0]?.id ?? "");
+  const { stayMode } = useStayMode();
+
+  useEffect(() => {
+    const stored = localStorage.getItem("video-last");
+    if (stored) {
+      setSelectedId(stored);
+    }
+  }, []);
+
+  const currentVideo = useMemo(() => videoItems.find((v) => v.id === selectedId) ?? videoItems[0], [selectedId]);
+
+  const selectVideo = (id: string) => {
+    setSelectedId(id);
+    localStorage.setItem("video-last", id);
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)]">
+      <div className="grid gap-4 sm:grid-cols-2">
+        {videoItems.map((video) => (
+          <button
+            key={video.id}
+            onClick={() => selectVideo(video.id)}
+            className={clsx(
+              "flex flex-col rounded-2xl border px-3 py-3 text-left transition",
+              selectedId === video.id
+                ? "border-candle bg-candle/10 text-white"
+                : "border-white/10 text-white/80 hover:border-white/30"
+            )}
+          >
+            <div
+              className={clsx("h-40 w-full rounded-xl bg-cover bg-center", stayMode ? "grayscale" : "")}
+              style={{ backgroundImage: `url(${video.coverUrl})` }}
+            />
+            <div className="mt-3">
+              <span className="rounded-full border border-white/20 px-2 py-0.5 text-xs text-candle">{video.type}</span>
+              <h3 className="mt-2 text-lg font-semibold text-white">{video.title}</h3>
+              <p className="text-sm text-white/70">{video.description}</p>
+            </div>
+          </button>
+        ))}
+      </div>
+      <div className="rounded-3xl border border-white/10 bg-black/30 p-4">
+        <p className="text-xs uppercase tracking-[0.3em] text-candle/70">Đang xem</p>
+        <h3 className="text-xl font-semibold text-white">{currentVideo?.title}</h3>
+        <p className="text-sm text-white/70">{currentVideo?.description}</p>
+        <div className="mt-4 overflow-hidden rounded-2xl bg-black">
+          {currentVideo && iframeProviders.has(currentVideo.sourceProvider) ? (
+            <iframe
+              title={currentVideo.title}
+              src={currentVideo.resolvedStreamUrl}
+              className="h-64 w-full"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowFullScreen
+            />
+          ) : (
+            <video className="h-64 w-full" controls src={currentVideo?.resolvedStreamUrl} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/data/episodes.ts
+++ b/src/data/episodes.ts
@@ -1,0 +1,172 @@
+export type Episode = {
+  id: string;
+  title: string;
+  description: string;
+  duration: string;
+  part: "I" | "II" | "III" | "IV" | "V";
+  chapterIndex: number;
+  coverUrl: string;
+  tags: string[];
+  sourceProvider: string;
+  resolvedStreamUrl: string;
+  moodPrompt: string;
+};
+
+export type VideoItem = {
+  id: string;
+  title: string;
+  type: "Full" | "Clip";
+  part: "I" | "II" | "III" | "IV" | "V";
+  description: string;
+  coverUrl: string;
+  sourceProvider: string;
+  resolvedStreamUrl: string;
+};
+
+export const podcastEpisodes: Episode[] = [
+  {
+    id: "p1",
+    title: "Phòng chờ – Cửa khép",
+    description: "Người Ở Lại thức trắng cạnh cửa phòng mổ, nghe tiếng đèn trắng reo lên trong đầu.",
+    duration: "14:23",
+    part: "I",
+    chapterIndex: 1,
+    coverUrl: "https://placehold.co/300x300/1f1c24/f6c28b?text=Phan+I",
+    tags: ["bệnh viện", "đèn trắng", "phòng chờ"],
+    sourceProvider: "mock",
+    resolvedStreamUrl: "https://cdn.pixabay.com/download/audio/2022/03/15/audio_example1.mp3",
+    moodPrompt: "Đặt tay lên ngực, thở cùng ánh đèn trắng."
+  },
+  {
+    id: "p2",
+    title: "Mi Đô và nồi cơm trống",
+    description: "Âm thanh của chiếc nồi cơm gõ nhịp cùng ký ức về Mi Đô trong bếp tối.",
+    duration: "18:09",
+    part: "II",
+    chapterIndex: 2,
+    coverUrl: "https://placehold.co/300x300/1f1c24/f6c28b?text=Phan+II",
+    tags: ["gia đình", "Mi Đô", "nồi cơm"],
+    sourceProvider: "mock",
+    resolvedStreamUrl: "https://cdn.pixabay.com/download/audio/2022/03/15/audio_example2.mp3",
+    moodPrompt: "Nhắm mắt và tưởng tượng hơi ấm căn bếp."
+  },
+  {
+    id: "p3",
+    title: "Hai ca mổ, hai lời thì thầm",
+    description: "Giữa tiếng máy monitor, hai giọng nội tâm trò chuyện về việc ở lại.",
+    duration: "22:47",
+    part: "III",
+    chapterIndex: 3,
+    coverUrl: "https://placehold.co/300x300/1f1c24/f6c28b?text=Phan+III",
+    tags: ["phẫu thuật", "ở lại", "song thoại"],
+    sourceProvider: "mock",
+    resolvedStreamUrl: "https://cdn.pixabay.com/download/audio/2022/03/15/audio_example3.mp3",
+    moodPrompt: "Ghi xuống một điều bạn muốn thì thầm với chính mình."
+  },
+  {
+    id: "p4",
+    title: "Lá thư 25/7/2024",
+    description: "Một lá thư chưa gửi nói về người đã đi và người ở lại.",
+    duration: "16:58",
+    part: "IV",
+    chapterIndex: 4,
+    coverUrl: "https://placehold.co/300x300/1f1c24/f6c28b?text=Phan+IV",
+    tags: ["lá thư", "ký ức", "chữa lành"],
+    sourceProvider: "mock",
+    resolvedStreamUrl: "https://cdn.pixabay.com/download/audio/2022/03/15/audio_example4.mp3",
+    moodPrompt: "Viết một dòng thư cho chính bạn trong tương lai."
+  },
+  {
+    id: "p5",
+    title: "Hồi ức của ước mơ",
+    description: "Kết lại hành trình 2020–2025 bằng giấc mơ màu tro và lời chào bình minh.",
+    duration: "20:05",
+    part: "V",
+    chapterIndex: 5,
+    coverUrl: "https://placehold.co/300x300/1f1c24/f6c28b?text=Phan+V",
+    tags: ["giấc mơ", "hy vọng", "bình minh"],
+    sourceProvider: "mock",
+    resolvedStreamUrl: "https://cdn.pixabay.com/download/audio/2022/03/15/audio_example5.mp3",
+    moodPrompt: "Đặt chuông nhắc nghỉ ngơi trước khi bước tiếp."
+  }
+];
+
+export const videoItems: VideoItem[] = [
+  {
+    id: "v1",
+    title: "Phần I – Người Ở Lại",
+    type: "Full",
+    part: "I",
+    description: "Video hành trình mở đầu trong phòng bệnh với ánh nến vàng.",
+    coverUrl: "https://placehold.co/600x400/1f1c24/f6c28b?text=Video+I",
+    sourceProvider: "YouTube",
+    resolvedStreamUrl: "https://www.youtube.com/embed/ysz5S6PUM-U"
+  },
+  {
+    id: "v2",
+    title: "Mi Đô nhớ bà",
+    type: "Clip",
+    part: "II",
+    description: "Đoạn cắt ghi lại câu chuyện Mi Đô và nồi cơm trống.",
+    coverUrl: "https://placehold.co/600x400/1f1c24/f6c28b?text=Video+II",
+    sourceProvider: "Vimeo",
+    resolvedStreamUrl: "https://player.vimeo.com/video/76979871?h=bf4d16c0b7"
+  },
+  {
+    id: "v3",
+    title: "Linh cảm trước ca mổ",
+    type: "Clip",
+    part: "III",
+    description: "Short form về hai giọng nội tâm trước phòng mổ.",
+    coverUrl: "https://placehold.co/600x400/1f1c24/f6c28b?text=Video+III",
+    sourceProvider: "YouTube",
+    resolvedStreamUrl: "https://www.youtube.com/embed/21X5lGlDOfg"
+  }
+];
+
+export const partsMeta = [
+  {
+    part: "I",
+    title: "Ngọn nến trong phòng chờ",
+    summary: "2020 – Đối diện khoảng tối đầu tiên tại bệnh viện.",
+    symbols: ["ngọn nến", "ánh đèn trắng"],
+    voices: ["Người Ở Lại"]
+  },
+  {
+    part: "II",
+    title: "Bếp trống, Mi Đô",
+    summary: "2021 – Gia đình, căn bếp, nồi cơm và cảm giác mất mát.",
+    symbols: ["nồi cơm", "Mi Đô"],
+    voices: ["Người Ở Lại", "Phần Yếu Mềm"]
+  },
+  {
+    part: "III",
+    title: "Hai ca mổ",
+    summary: "2022 – Hai lần nhập viện, hai cuộc đối thoại nội tâm.",
+    symbols: ["dao mổ", "monitor"],
+    voices: ["Người Ở Lại", "Phần Yếu Mềm"]
+  },
+  {
+    part: "IV",
+    title: "Lá thư chưa gửi",
+    summary: "2023–2024 – Những lời chưa kịp nói, bức thư 25/7/2024.",
+    symbols: ["lá thư", "bàn tay"],
+    voices: ["Người Ở Lại"]
+  },
+  {
+    part: "V",
+    title: "Hồi ức của ước mơ",
+    summary: "2025 – Hành trình chạm tới ánh sáng và chọn ở lại.",
+    symbols: ["bình minh", "màu tro"],
+    voices: ["Người Ở Lại", "Phần Yếu Mềm"]
+  }
+] as const;
+
+export const timelineEvents = [
+  { year: 2020, title: "Ngọn nến", detail: "Đêm đầu tiên túc trực bên giường bệnh." },
+  { year: 2021, title: "Nồi cơm trống", detail: "Căn bếp thiếu một hơi ấm." },
+  { year: 2022, title: "Hai ca mổ", detail: "Hai lần ký cam kết và đối thoại với nội tâm." },
+  { year: 2023, title: "Mi Đô", detail: "Chú mèo trở lại với vết sẹo ngang tai." },
+  { year: 2024, title: "Lá thư 25/7/2024", detail: "Bức thư gửi chính mình không gửi đi." },
+  { year: 2025, title: "Ở lại", detail: "Bình minh trong phòng tối, lựa chọn tiếp tục." }
+];

--- a/src/lib/link-resolver.ts
+++ b/src/lib/link-resolver.ts
@@ -1,0 +1,85 @@
+export type ResolverOutput = {
+  source_provider: string;
+  resolved_stream_url: string;
+  embed_type: "html5" | "iframe" | "hls";
+  mime_type: string;
+  duration_estimate: string;
+  note?: string;
+};
+
+export interface LinkAdapter {
+  id: string;
+  match: (url: string) => boolean;
+  resolve: (url: string) => ResolverOutput;
+}
+
+const toResult = (provider: string, url: string, extra?: Partial<ResolverOutput>): ResolverOutput => ({
+  source_provider: provider,
+  resolved_stream_url: url,
+  embed_type: extra?.embed_type ?? "html5",
+  mime_type: extra?.mime_type ?? "audio/mpeg",
+  duration_estimate: extra?.duration_estimate ?? "~18:00",
+  note: extra?.note
+});
+
+const adapters: LinkAdapter[] = [
+  {
+    id: "google-drive",
+    match: (url) => /drive\.google/.test(url),
+    resolve: (url) => toResult("Google Drive", url.replace("view?usp=sharing", "preview"), { embed_type: "iframe", mime_type: "video/mp4" })
+  },
+  {
+    id: "dropbox",
+    match: (url) => /dropbox\.com/.test(url),
+    resolve: (url) => toResult("Dropbox", url.replace("dl=0", "raw=1"))
+  },
+  {
+    id: "onedrive",
+    match: (url) => /1drv\.ms|sharepoint/.test(url),
+    resolve: (url) => toResult("OneDrive", url, { embed_type: "iframe", mime_type: "video/mp4", note: "Sử dụng viewer của Microsoft" })
+  },
+  {
+    id: "youtube",
+    match: (url) => /youtube|youtu\.be/.test(url),
+    resolve: (url) => {
+      const videoId = url.split("v=")[1] ?? url.split("/").pop();
+      return toResult("YouTube", `https://www.youtube.com/embed/${videoId}`, { embed_type: "iframe", mime_type: "text/html", duration_estimate: "theo metadata" });
+    }
+  },
+  {
+    id: "vimeo",
+    match: (url) => /vimeo\.com/.test(url),
+    resolve: (url) => toResult("Vimeo", url.replace("vimeo.com", "player.vimeo.com/video"), { embed_type: "iframe", mime_type: "text/html" })
+  },
+  {
+    id: "soundcloud",
+    match: (url) => /soundcloud\.com/.test(url),
+    resolve: (url) => toResult("SoundCloud", url, { embed_type: "iframe", mime_type: "text/html" })
+  },
+  {
+    id: "direct",
+    match: (url) => /\.(mp3|mp4|m3u8)($|\?)/.test(url),
+    resolve: (url) => {
+      const ext = url.split(".").pop()?.split("?")[0];
+      const mime = ext === "mp4" ? "video/mp4" : ext === "m3u8" ? "application/x-mpegURL" : "audio/mpeg";
+      return toResult("Direct", url, { mime_type: mime, embed_type: ext === "m3u8" ? "hls" : "html5" });
+    }
+  },
+  {
+    id: "s3",
+    match: (url) => /amazonaws\.com|r2\.cloudflarestorage\.com/.test(url),
+    resolve: (url) => toResult("S3 / R2", url, { note: "URL ký tên tạm thời" })
+  }
+];
+
+export function resolveMediaLink(url: string): ResolverOutput {
+  const adapter = adapters.find((ad) => ad.match(url));
+  if (adapter) {
+    return adapter.resolve(url);
+  }
+  return toResult("Không xác định", url, { note: "Không tìm thấy adapter phù hợp" });
+}
+
+export function listAdapters() {
+  return adapters.map((adapter) => adapter.id);
+}

--- a/src/lib/mock-gemini.ts
+++ b/src/lib/mock-gemini.ts
@@ -1,0 +1,30 @@
+export type GeminiCover = {
+  id: string;
+  title: string;
+  url: string;
+};
+
+const motifs = [
+  "cửa khép – bệnh viện – ánh đèn trắng",
+  "nồi cơm – căn bếp",
+  "Mi Đô",
+  "giấc mơ màu tro – phân ly",
+  "ngọn nến – phòng tối"
+];
+
+export async function generateCovers(seed: string): Promise<GeminiCover[]> {
+  return motifs.map((motive, index) => ({
+    id: `${seed}-${index}`,
+    title: `${seed} · ${motive}`,
+    url: `https://placehold.co/400x400/0f0f0f/FFFFFF?text=${encodeURIComponent(motive)}`
+  }));
+}
+
+export async function generateDescription(prompt: string): Promise<string> {
+  return `AI mô tả: ${prompt} – hai câu chuyện đan xen giữa ký ức bệnh viện và căn bếp tối.`;
+}
+
+export async function generateTags(seed?: string): Promise<string[]> {
+  const base = ["sang chấn", "phân ly", "PTSD phức hợp", "gia đình", "bệnh viện", "bà ngoại", "Mi Đô", "Tuấn", "healing", "LGBTQ+", "ở lại", "ký ức"];
+  return seed ? base.filter((_, index) => index % 2 === 0) : base;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,38 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        stay: {
+          bg: "#0d0d0d",
+          text: "#bfbfbf",
+          accent: "#888888"
+        },
+        candle: "#f9d9a9",
+        dusk: "#1b1a1e",
+        "soft-green": "#8aa6a3"
+      },
+      boxShadow: {
+        lullaby: "0 20px 60px rgba(0,0,0,0.35)"
+      },
+      animation: {
+        "slow-fade": "slowFade 1.4s ease both"
+      },
+      keyframes: {
+        slowFade: {
+          "0%": { opacity: 0, transform: "translateY(10px)" },
+          "100%": { opacity: 1, transform: "translateY(0)" }
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js + Tailwind app with Stay Mode, podcast/video tabs, timeline page, and healing oriented hero/footer copy
- add local-storage aware podcast + video experiences, linear journey mode, and rich admin panel with mock Gemini AI + link resolver adapters
- document project structure and usage instructions in the README

## Testing
- `npm run lint` *(fails: `next` binary missing because dependencies are not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918dfd2dd608330870b5485fc47f65e)